### PR TITLE
Use native diff log for git

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var config = require('./config'),
 	Vcs = require('./lib/vcs/' + config.vcs.type),
-	Builder = require('./lib/builder'),
 	Epic = require('./lib/epics/' + config.epics.type + 'Epic'),
 	Printer = require('./lib/printer/terminalprinter'),
 	CommitIgnore = require('./lib/processor/commitignore'),
@@ -12,37 +11,19 @@ if (process.argv.length < 4) return console.error('Missing argument: Usage node 
 var oldBranch = process.argv[2];
 var newBranch = process.argv[3];
 
-
 var vcs = new Vcs(),
-	builder = new Builder(),
 	printer = new Printer(),
 	epic = new Epic(),
 	commitIgnore = new CommitIgnore(),
 	uniqueIssues = new UniqueIssues(),
 	commitLength = new CommitLength();
 
-var count = 0;
-
-function diff() {
-	var logDiff = builder.getDiff();
+vcs.getDiffLog(oldBranch, newBranch, function(logDiff) {
 	logDiff = commitIgnore.process(config, logDiff);
 	logDiff = commitLength.process(config, logDiff);
 	logDiff = uniqueIssues.process(config, logDiff);
+
 	epic.parse(logDiff, function (groupedCommits) {
 		printer.printChangeLog(groupedCommits);
-	});
-}
-
-vcs.getMinVersion(oldBranch, newBranch, function (minRevision) {
-	vcs.getLog(oldBranch, minRevision, function (log) {
-		builder.setOldLog(log);
-		if (0 === count) count++;
-		else diff();
-	});
-
-	vcs.getLog(newBranch, minRevision, function (log) {
-		builder.setNewLog(log);
-		if (0 === count) count++;
-		else diff();
 	});
 });

--- a/lib/vcs/git.js
+++ b/lib/vcs/git.js
@@ -1,19 +1,20 @@
-var exec = require('child_process').exec;
+var exec = require('child_process').exec,
+	LogParser = require('../parser/gitlog'),
+	parser = new LogParser();
+	util = require('util');
 
 function Git() {
 
 }
 
-Git.prototype.getLog = function (branch, minRevision, callback) {
-	exec("git log --no-merges '" + branch+"'", {maxBuffer: 1024 * 10000}, function (err, stdout, stderr) {
+Git.prototype.getDiffLog = function (fromBranch, toBranch, callback) {
+	var command = util.format("git log --no-merges '%s'..'%s'", fromBranch, toBranch);
+
+	exec(command, {maxBuffer: 1024 * 1024 * 10}, function (err, stdout, stderr) {
 		if (err) throw err;
 
-		callback(stdout);
+		callback(parser.parse(stdout));
 	});
-};
-
-Git.prototype.getMinVersion = function (oldBranch, newBranch, callback) {
-	callback(0);
 };
 
 module.exports = Git;

--- a/lib/vcs/svn.js
+++ b/lib/vcs/svn.js
@@ -2,11 +2,33 @@ var exec = require('child_process').exec,
 	ArrayHelper = require('../util/arrayhelper'),
 	arrayHelper = new ArrayHelper(),
 	config = require('../../config'),
+	Builder = require('../builder'),
 	util = require('util');
 
 function Svn() {
 
 }
+
+Svn.prototype.getDiffLog = function (fromBranch, toBranch, callback) {
+	var builder = new Builder();
+	var count = 0;
+
+	this.getMinVersion(fromBranch, toBranch, function (minRevision) {
+		this.getLog(fromBranch, minRevision, function (log) {
+			builder.setOldLog(log);
+			if (count++) {
+				callback(builder.getDiff());
+			}
+		});
+
+		this.getLog(toBranch, minRevision, function (log) {
+			builder.setNewLog(log);
+			if (count++) {
+				callback(builder.getDiff());
+			}
+		});
+	}.bind(this));
+};
 
 Svn.prototype.getLog = function (branch, minRevision, callback) {
 	this._executeSvnCommand(util.format("log -g -r %s:HEAD %s%s", minRevision, config.vcs.path, branch),  function (err, stdout, stderr) {
@@ -17,14 +39,13 @@ Svn.prototype.getLog = function (branch, minRevision, callback) {
 };
 
 Svn.prototype.getMinVersion = function (oldBranch, newBranch, callback) {
-	var self = this;
 	this.getRevisionsForBranch(oldBranch, function (oldRevisions) {
-		self.getRevisionsForBranch(newBranch, function (newRevisions) {
+		this.getRevisionsForBranch(newBranch, function (newRevisions) {
 			var revisionDiff = arrayHelper.diff(newRevisions, oldRevisions);
 
 			callback(Math.min.apply(null, revisionDiff) - 1);
 		});
-	});
+	}.bind(this));
 };
 
 Svn.prototype.getRevisionsForBranch = function (branch, callback) {
@@ -65,7 +86,7 @@ Svn.prototype._executeSvnCommand = function(command, callback) {
 		command_string += util.format(" --username=%s --password=%s", config.vcs.user, config.vcs.password);
 	}
 
-	exec(command_string, {maxBuffer: 1024 * 10000}, callback);
+	exec(command_string, {maxBuffer: 1024 * 1024 * 100}, callback);
 };
 
 module.exports = Svn;


### PR DESCRIPTION
Instead of diff'ing huge logs use the native diff log for git. This is faster and requires less memory while buffering the log outputs.

```
time node ../changelog-builder/index.js release/1.60 release/1.61

Old: 3,96s user 0,33s system 84% cpu 5,081 total
New: 0,24s user 0,05s system 14% cpu 1,997 total
```

There is no significant change for the SVN behavior.
