### PR TITLE
Default issues are shown twice

### DIFF
--- a/lib/epics/JiraEpic.js
+++ b/lib/epics/JiraEpic.js
@@ -110,11 +110,7 @@ JiraEpic.prototype.fetchEpicNames = function (epics, issuesToCommits, commitsWit
 			groupedCommits[issue.fields[epicNameFieldId]] = [];
 			for (var l in epics[issue.key]) {
 				groupedCommits[issue.fields[epicNameFieldId]].push(issuesToCommits[epics[issue.key][l]]);
-				delete issuesToCommits[epics[issue.key][l]];
 			}
-		}
-		for (var j in issuesToCommits) {
-			groupedCommits.default.push(issuesToCommits[j]);
 		}
 
 		callback(groupedCommits);


### PR DESCRIPTION
Issues without epics were already added to the default epic before. This fix removes the loop, where those issues get added again.
