### PR TITLE
Processor for unique messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var config = require('./config'),
 	Printer = require('./lib/printer/terminalprinter'),
 	CommitIgnore = require('./lib/processor/commitignore'),
 	UniqueIssues = require('./lib/processor/uniqueissues'),
+	UniqueMessages = require('./lib/processor/uniquemessages'),
 	CommitLength = require('./lib/processor/commitlength');
 
 if (process.argv.length < 4) return console.error('Missing argument: Usage node index.js old_branch new_branch');
@@ -19,6 +20,7 @@ var vcs = new Vcs(),
 	epic = new Epic(),
 	commitIgnore = new CommitIgnore(),
 	uniqueIssues = new UniqueIssues(),
+	uniqueMessages = new UniqueMessages(),
 	commitLength = new CommitLength();
 
 var count = 0;
@@ -28,6 +30,7 @@ function diff() {
 	logDiff = commitIgnore.process(config, logDiff);
 	logDiff = commitLength.process(config, logDiff);
 	logDiff = uniqueIssues.process(config, logDiff);
+	logDiff = uniqueMessages.process(logDiff);
 	epic.parse(logDiff, function (groupedCommits) {
 		printer.printChangeLog(groupedCommits);
 	});

--- a/lib/processor/uniquemessages.js
+++ b/lib/processor/uniquemessages.js
@@ -1,0 +1,22 @@
+function UniqueMessages() {
+
+}
+
+UniqueMessages.prototype.process = function (commits) {
+	var seen = {};
+	var result = {};
+	var message;
+
+	for (var key in commits) {
+		message = commits[key];
+
+		if (!seen[message]) {
+			seen[message] = true;
+			result[key] = message;
+		}
+	}
+
+	return result;
+};
+
+module.exports = UniqueMessages;

--- a/test/processor/uniquemessages.js
+++ b/test/processor/uniquemessages.js
@@ -1,0 +1,26 @@
+var test = require('tape'),
+	UniqueMessages = require('../../lib/processor/uniquemessages'),
+	uniquemessages = new UniqueMessages();
+
+
+test('uniquemessages process', function (t) {
+	t.plan(1);
+
+	var diff = {
+		1: 'updated something without issue',
+		2: 'did something else',
+		3: 'updated something without issue',
+		4: 'fixed #123',
+		5: 'updated something without issue'
+	};
+
+	var actual = uniquemessages.process(diff);
+
+	var expected = {
+		1: 'updated something without issue',
+		2: 'did something else',
+		4: 'fixed #123'
+	};
+
+	t.deepEqual(actual, expected);
+});


### PR DESCRIPTION
A changelog should not contain duplicate messages. This processor filters those duplicates, independently of the presence of an issue ID.
